### PR TITLE
Removed .exe in timer code

### DIFF
--- a/Launcher/Launcher/Launcher.vb
+++ b/Launcher/Launcher/Launcher.vb
@@ -197,7 +197,7 @@ Public Class frmLauncher
         'This code will run every 1 minutes if UploadTime is Enabled. It will add 1 minute, then if the game is closed,  upload and exit.
         minutesPlayed += 1
 
-        Dim isRunning = Process.GetProcessesByName("openrct2.exe")
+        Dim isRunning = Process.GetProcessesByName("openrct2")
         If isRunning.Count > 0 Then
             ' Process is running
         Else


### PR DESCRIPTION
https://social.msdn.microsoft.com/Forums/vstudio/en-US/77153d31-a23f-48d0-a4c4-2a3867370af6/vbnet-check-to-see-if-a-process-is-running

With .exe, the timer made the launcher stop after 1 minute. You don't have to provide the .exe in the processname (as explained on the url above)
